### PR TITLE
ci: retry trendecon install to ride out GitHub API flakes

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -67,7 +67,23 @@ jobs:
         shell: Rscript {0}
         run: |
           install.packages(c("remotes", "prophet", "tibble"))
-          remotes::install_github("trendecon/trendecon@v0.3.2", upgrade = "never")
+          # The three matrix jobs hit the GitHub API in parallel to resolve the
+          # trendecon tag; transient "cannot open URL" errors there have failed
+          # individual countries. Retry with backoff so a flake no longer skips
+          # a country's daily update.
+          ok <- FALSE
+          for (i in 1:5) {
+            ok <- tryCatch({
+              remotes::install_github("trendecon/trendecon@v0.3.2", upgrade = "never")
+              TRUE
+            }, error = function(e) {
+              message("install attempt ", i, " failed: ", conditionMessage(e))
+              FALSE
+            })
+            if (ok) break
+            Sys.sleep(15 * i)
+          }
+          if (!ok) stop("Failed to install trendecon after 5 attempts")
 
       - name: Update indices for ${{ matrix.geo }}
         if: steps.gate.outputs.run == 'true'


### PR DESCRIPTION
## Problem

In [run 28315477661](https://github.com/trendecon/data/actions/runs/28315477661), the `de` and `ch` query jobs failed at **Install R dependencies** with:

```
Failed to install 'trendecon' from GitHub:
  cannot open URL 'https://api.github.com/repos/trendecon/trendecon/commits/v0.3.2'
```

The `v0.3.2` tag exists and resolves fine — this is a **transient GitHub API flake**. The three matrix jobs (`ch`/`de`/`at`) all resolve the tag against `api.github.com` in parallel, and a transient error there knocked out 2 of 3 while `at` went green. The `commit` job then committed `at`-only data, leaving `de`/`ch` without a fresh update for the day.

## Fix

Wrap the `remotes::install_github()` call in a 5-attempt retry loop with linear backoff (15s, 30s, 45s, 60s). Zero cost on the happy path; rides out the flake so a transient API error no longer skips a country's daily update.

No new triggers — the workflow still runs only on `schedule` / `workflow_dispatch`.